### PR TITLE
Rendering engine reuse

### DIFF
--- a/omero_catmaid/views.py
+++ b/omero_catmaid/views.py
@@ -67,10 +67,9 @@ def render_tile(request, iid, conn=None, **kwargs):
 	@param conn:        L{omero.gateway.BlitzGateway} connection
 	@return:            http response wrapping jpeg
 	"""
-	server_id = request.session['connector'].server_id
 
 	# login get image object
-	pi = webgateway_views._get_prepared_image(request, iid, server_id=server_id, conn=conn)
+	pi = webgateway_views._get_prepared_image(request, iid, conn=conn)
 
 	if pi is None:
 		raise Http404

--- a/omero_catmaid/views.py
+++ b/omero_catmaid/views.py
@@ -50,7 +50,56 @@ def index(request):
 	"""
 	return HttpResponse("Welcome to omero-catmaid app home-page!!!")
 
-@login_required()
+def getZoomLevelScaling(re):
+        """
+        Similar implementation to this method in Blitz Gateway.
+        Returns a dict of zoomLevels:scale (fraction) for tiled 'Big' images.
+        eg {0: 1.0, 1: 0.25, 2: 0.062489446727078291, 3: 0.031237687848258006}
+        Returns None if this image doesn't support tiles.
+        """
+        if not re.requiresPixelsPyramid():
+            return None
+        levels = re.getResolutionDescriptions()
+        rv = {}
+        sizeXList = [level.sizeX for level in levels]
+        for i, level in enumerate(sizeXList):
+            rv[i] = float(level)/sizeXList[0]
+        return rv
+
+def renderJpegRegion(re, z, t, x, y, width, height, level=None,
+                     compression=0.9):
+    """
+    Similar implementation to this method in Blitz Gateway.
+    Return the data from rendering a region of an image plane.
+    NB. Projection not supported by the API currently.
+
+    :param z:               The Z index. Ignored if projecting image.
+    :param t:               The T index.
+    :param x:               The x coordinate of region (int)
+    :param y:               The y coordinate of region (int)
+    :param width:           The width of region (int)
+    :param height:          The height of region (int)
+    :param compression:     Compression level for jpeg
+    :type compression:      Float
+    """
+
+    plane_def = omero.romio.PlaneDef(omero.romio.XY)
+    plane_def.z = long(z)
+    plane_def.t = long(t)
+
+    regionDef = omero.romio.RegionDef()
+    regionDef.x = int(x)
+    regionDef.y = int(y)
+    regionDef.width = int(width)
+    regionDef.height = int(height)
+    plane_def.region = regionDef
+    if level is not None:
+        re.setResolutionLevel(level)
+    if compression is not None:
+        re.setCompressionLevel(float(compression))
+    return re.renderCompressed(plane_def, {'omero.group': '-1'})
+
+@login_required(doConnectionCleanup=False)
 def render_tile(request, iid, conn=None, **kwargs):
 	"""
 	This function is rewritten based on the render_image_region function in omeroweb.webgateway.
@@ -67,18 +116,36 @@ def render_tile(request, iid, conn=None, **kwargs):
 	@param conn:        L{omero.gateway.BlitzGateway} connection
 	@return:            http response wrapping jpeg
 	"""
+	services = conn.c.sf.activeServices()
+	re = None
+	# Try to re-use existing Rendering Engine...
+	for s in services:
+		if 'RenderingEngine' in s:
+			p = conn.c.sf.getByName(s)
+			r = omero.api.RenderingEnginePrx.checkedCast(p)
+			pixels = r.getPixels()
+			image_id = pixels.getImage().id.val
+			# ...if we find a Rendering Engine with correct image ID, use it...
+			if long(iid) == image_id:
+				re = r
+			else:
+				# ...otherwise close()
+				r.close()
 
-	# login get image object
-	pi = webgateway_views._get_prepared_image(request, iid, conn=conn)
+	if re is not None:
+		# NB: Seems we can't call re.getResolutionDescriptions() here, get:
+		# serverExceptionClass = ome.conditions.InternalException
+		# message =  Wrapped Exception: (java.lang.IllegalStateException):
+		# ImageReader.getResolutionCount: Current file should not be null; call setId(String) first
+		zoomLevelScaling = getZoomLevelScaling(re)
+	else:
+		pi = webgateway_views._get_prepared_image(request, iid, conn=conn)
 
-	if pi is None:
-		raise Http404
-	img, compress_quality = pi
+		if pi is None:
+			raise Http404
+		img, compress_quality = pi
+		zoomLevelScaling = img.getZoomLevelScaling()
 	
-	# prepare image rendering
-	# TODO: this step is similar for all requests => use cache, session ???
-	
-	zoomLevelScaling = img.getZoomLevelScaling()
 	max_level = len(zoomLevelScaling.keys()) - 1
 
 	# get query parameters
@@ -92,7 +159,7 @@ def render_tile(request, iid, conn=None, **kwargs):
 
 	x,y,w,h = float(x),float(y),int(float(w)),int(float(h))
 	zm = int(zm)
-	compress_quality = int(compress_quality)
+	compress_quality = 90  # int(compress_quality)
 
 	level = max_level - zm
 
@@ -101,8 +168,12 @@ def render_tile(request, iid, conn=None, **kwargs):
 	scaley = y * zoomLevelScaling[zm]
 
 	# render image
-	jpeg_data = img.renderJpegRegion(z, t, scalex, scaley, w, h, level=level,
-				                          compression=(compress_quality/100.0))
+	if re is not None:
+		jpeg_data = renderJpegRegion(re, z, t, scalex, scaley, w, h, level=level,
+									 compression=(compress_quality/100.0))
+	else:
+		jpeg_data = img.renderJpegRegion(z, t, scalex, scaley, w, h, level=level,
+										 compression=(compress_quality/100.0))
 
 	return HttpResponse(jpeg_data, content_type='image/jpeg')
 


### PR DESCRIPTION
This PR outlines a potential approach for re-using a rendering engine for repeated rendering of tiles from the same image.

Instead of caching a reference to the Rendering Engine in Redis or Django session as discussed today, we simply use ```serviceFactory.activeServices()``` to find existing Rendering Engines and pick the first one that is initialised with the Image that we want.

The major issue so far is that ```re.getResolutionDescriptions()``` fails with newly re-created rendering engines, even though ```re.renderCompressed()``` works fine. Any ideas @joshmoore?
At least when I hard-code a work-around to this line, the re-use of rendering engine certainly speeds up the retrieval of tiles.

Other TODOs:
 - decide how to close all rendering engines when we're done (currently we close any that don't match the current image)
 - test this in a production setup where Catmaid is loading many tiles simultaneously with multiple web workers